### PR TITLE
コメント投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,4 @@ end
   gem "devise"
   gem 'mini_magick'
   gem 'image_processing', '~> 1.12.0'
+  gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -141,6 +142,11 @@ GEM
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -240,6 +246,7 @@ DEPENDENCIES
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   selenium-webdriver

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,19 @@
+class CommentsController < ApplicationController
+
+  def create
+    @prototype = Prototype.find(params[:prototype_id])
+    @comment = @prototype.comments.new(comment_params)
+    if @comment.save
+      redirect_to prototype_path(@comment.prototype.id)
+    else 
+      @comments = @prototype.comments.includes(:user)
+      render "tweets/show", status: :unprocessable_entity
+    end
+
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -18,6 +18,8 @@ class PrototypesController < ApplicationController
 
   def show
     @prototype = Prototype.find(params[:id])
+    @comment =  Comment.new
+    @comments = @prototype.comments.includes(:user)
 
   end
 
@@ -43,6 +45,6 @@ class PrototypesController < ApplicationController
   private
 
   def prototype_params
-    params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+    params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id, prototype_id: params[:id] )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :prototype
+
+  validates :content, presence: true
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,5 +1,6 @@
 class Prototype < ApplicationRecord
   belongs_to :user
+  has_many :comments, dependent: :destroy
   has_one_attached :image
 
   validates :title, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
   validates :position, presence: true
 
   has_many :prototypes
+  has_many :comments
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -31,23 +31,29 @@
         </div>
       </div>
       <div class="prototype__comments">
+      <% if user_signed_in? %>
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
-            <div class="field">
-              <%# <%= f.label :hoge, "コメント" %><br />
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
-            </div>
-            <div class="actions">
-              <%# <%= f.submit "送信する", class: :form__btn  %>
-            </div>
-          <%# <% end %>
-        <%# // ログインしているユーザーには上記を表示する %>
+        <%= form_with model: [@prototype, @comment],local: true do |f| %>
+          <div class="field">
+            <%# <%= f.label :content, "コメント"<br /> %>
+            <%= f.label :content, "コメント" %><br />
+            <%= f.text_field :content, id:"comment_content" %>
+          </div>
+          <div class="actions">
+            <%= f.submit "送信する", class: :form__btn %>
+          </div>
+        <% end %>
+      <% end %>
+        <%# //  ログインしているユーザーには上記を表示する %>
+
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
+          <% @comments.each do |comment| %>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+                <%= comment.content %>
+              <%= link_to comment.user.name, root_path, class: :comment_user %>
             </li>
+            <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'prototypes/index'
   root to: "prototypes#index" 
-  resources :prototypes
+  resources :prototypes do
+    resources :comments, only: :create
+  end 
 end

--- a/db/migrate/20230825032452_create_comments.rb
+++ b/db/migrate/20230825032452_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :prototype, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_065246) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_25_032452) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_065246) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "prototype_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prototype_id"], name: "index_comments_on_prototype_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "prototypes", charset: "utf8", force: :cascade do |t|
@@ -67,5 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_065246) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "prototypes"
+  add_foreign_key "comments", "users"
   add_foreign_key "prototypes", "users"
 end


### PR DESCRIPTION
# WHAT
詳細ページからコメントを投稿する実装

# WHY
コメントのテキストを表示
情報が欠けていると、保存をすることができない。
投稿フォームはログインしているときのみに表示される。