### PR TITLE
ログインしていないユーザーのページ遷移を制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,6 @@
 class PrototypesController < ApplicationController
+before_action :authenticate_user!, only: [:new, :edit, :destory ]
+
   def index
     @prototypes = Prototype.includes(:user)
   end
@@ -25,6 +27,9 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
+    unless @prototype.user == current_user
+      redirect_to root_path
+    end
   end
 
   def update


### PR DESCRIPTION
# WHAT
・ログインしていないユーザーのページ遷移を制限すること
・投稿者以外のユーザーが、投稿者専用のページに遷移できないように制限すること

# WHY
・ユーザーのログイン状態によってページ遷移を制限
・URLを直接入力すると他のユーザーが保存したプロトタイプ編集ページにも遷移できてまうため
他ユーザーのプロトタイプ編集ページに遷移したら、トップページに戻るようにしましょう。